### PR TITLE
Gen cesm catalog

### DIFF
--- a/cesmcatalog/gen_CESM_catalog.py
+++ b/cesmcatalog/gen_CESM_catalog.py
@@ -17,6 +17,9 @@ import sys
 import subprocess
 import logging
 import argparse
+import fnmatch
+
+import pandas as pd
 
 ################################################################################
 
@@ -41,18 +44,18 @@ def _find_data(case_root):
     os.chdir(case_root)
   except:
     # TODO: set up logger instead of print statements
-    logger.error('%s does not exist' % case_root)
+    logger.error('{} does not exist'.format(case_root))
     sys.exit(1)
 
   # 2. Collect info on where time slice output is
   if not os.path.isfile('./xmlquery'):
     # TODO: set up logger instead of print statements
-    logger.error('Can not find xmlquery in %s' % case_root)
+    logger.error('Can not find xmlquery in {}'.format(case_root))
     sys.exit(1)
 
   run_config = dict()
   for var in ['GET_REFCASE', 'RUN_REFCASE']:
-    run_config[var] = subprocess.check_output('./xmlquery --value %s' % var, shell=True)
+    run_config[var] = subprocess.check_output('./xmlquery --value {}'.format(var), shell=True)
   DOUT_S = subprocess.check_output('./xmlquery --value DOUT_S', shell=True)
   if DOUT_S == 'TRUE':
     DOUT_S_ROOT = subprocess.check_output('./xmlquery --value DOUT_S_ROOT', shell=True)
@@ -71,28 +74,97 @@ def _find_data(case_root):
 
 ################################################################################
 
+def _gen_timeslice_catalog(case_root, archive_root, run_config):
+  # TODO: figure out how to generate catalog from time slice
+  logger = logging.getLogger(__name__)
+  logger.info('Will catalog files in {}'.format(archive_root))
+
+################################################################################
+
+def _gen_timeseries_catalog(case_root, archive_root, run_config):
+  # Set up logger
+  # Define casename, file to create, and columns the catalog will contain
+  logger = logging.getLogger(__name__)
+  casename = case_root.split('/')[-1]
+  out_file = 'cesm_catalog.csv.gz'
+  col_order = ['case', 'component', 'stream', 'variable', 'start_date', 'end_date', 'path', 'parent_branch_year', 'child_branch_year', 'parent_case']
+
+ # cd archive_root and make sure intake/ subdirectory exists (for output)
+  os.chdir(archive_root)
+  if not os.path.isdir('intake'):
+    os.mkdir('intake')
+
+  # want paths in catalog to be relative to location of catalog
+  os.chdir('intake')
+  logger.info('Will catalog files in {}'.format(archive_root))
+  catalog = dict()
+  for col_name in col_order:
+    catalog[col_name] = []
+
+  # Find each netcdf file in directory
+  for root, dirs, files in os.walk('..'):
+    for ncfile in fnmatch.filter(files, '*.nc'):
+      # each file should be {casename}.{stream}.{variable}.{start_date}-{end_date}.nc
+      # first we drop the leading {casename}.
+      file_without_case = ncfile.replace(casename, '')[1:]
+      # then we split on .
+      file_info = file_without_case.split('.')
+      # {stream} will have at least one . in it
+      # figure out how many by location of date_range
+      # (only part of filename that should contain a '-')
+      for date_ind, info in enumerate(file_info):
+        if len(info.split('-'))>1:
+          break
+
+      # Enough to determine stream, variable, start_date, and end_date
+      catalog['stream'].append('.'.join(file_info[:date_ind-1]))
+      catalog['variable'].append(file_info[date_ind-1])
+      date_range = info.split('-')
+      catalog['start_date'].append(date_range[0])
+      catalog['end_date'].append(date_range[1])
+
+      # path should be relative to intake/, so we keep root
+      catalog['path'].append(os.path.join(root, ncfile))
+      # component is the name of the subdirectory of archive_root
+      catalog['component'].append(catalog['path'][-1].split('/')[1])
+
+  # Columns that do not change by row
+  entry_cnt = len(catalog['path'])
+  catalog['case'] = entry_cnt*[casename]
+  if run_config['GET_REFCASE'] == 'TRUE':
+    catalog['parent_case'] = entry_cnt*[run_config['RUN_REFCASE']]
+    catalog['parent_branch_year'] = entry_cnt*[run_config['RUN_REFDATE']]
+    catalog['child_branch_year'] = entry_cnt*[run_config['RUN_STARTDATE']]
+  else:
+    catalog['parent_case'] = entry_cnt*['-']
+    catalog['parent_branch_year'] = entry_cnt*[-1]
+    catalog['child_branch_year'] = entry_cnt*[-1]
+
+  logger.info('Creating {}...'.format(os.path.join(os.getcwd(), out_file)))
+  pd.DataFrame(catalog).to_csv(out_file, index=False, columns=col_order, compression='gzip')
+
+################################################################################
+
 def gen_catalog(case_root):
   logger = logging.getLogger(__name__)
 
   # 1. Find where data is
   run_config, DOUT_S_ROOT, TIMESERIES_OUTPUT_ROOTDIR = _find_data(case_root)
   if (DOUT_S_ROOT is None) and (TIMESERIES_OUTPUT_ROOTDIR is None):
-    logger.error('Error: can not find any data for %s' % case_root)
+    logger.error('Error: can not find any data for {}'.format(case_root))
     sys.exit(1)
 
-  logger.info('run_config: %s' % run_config)
-
-  if DOUT_S_ROOT:
-    # TODO: generate catalog instead of just printing this
-    logger.info('DOUT_S_ROOT: %s' % DOUT_S_ROOT)
-
   if TIMESERIES_OUTPUT_ROOTDIR:
-    # TODO: generate catalog instead of just printing this
-    logger.info('TIMESERIES_OUTPUT_ROOTDIR: %s' % TIMESERIES_OUTPUT_ROOTDIR)
+    _gen_timeseries_catalog(case_root, TIMESERIES_OUTPUT_ROOTDIR, run_config)
+  else: # only generate time slice catalog if time series not available
+    _gen_timeslice_catalog(case_root, DOUT_S, run_config)
 
 ################################################################################
 
 if __name__ == "__main__":
   logging.basicConfig(format='%(levelname)s (%(funcName)s): %(message)s', level=logging.DEBUG)
   args = _parse_args()
+  # strip trailing / from case root (if user provides it)
+  while args.case_root[-1] == '/':
+    args.case_root = args.case_root[:-1]
   gen_catalog(args.case_root)

--- a/cesmcatalog/gen_CESM_catalog.py
+++ b/cesmcatalog/gen_CESM_catalog.py
@@ -50,27 +50,24 @@ def _find_data(case_root):
     logger.error('Can not find xmlquery in %s' % case_root)
     sys.exit(1)
 
+  run_config = dict()
+  for var in ['GET_REFCASE', 'RUN_REFCASE']:
+    run_config[var] = subprocess.check_output('./xmlquery --value %s' % var, shell=True)
   DOUT_S = subprocess.check_output('./xmlquery --value DOUT_S', shell=True)
   if DOUT_S == 'TRUE':
-    timeslice_config = dict()
-    for var in ['DOUT_S_ROOT', 'GET_REFCASE', 'RUN_REFCASE']:
-      timeslice_config[var] = subprocess.check_output('./xmlquery --value %s' % var, shell=True)
-    # Proof of concept; show what data we've gleaned
+    DOUT_S_ROOT = subprocess.check_output('./xmlquery --value DOUT_S_ROOT', shell=True)
   else:
-    timeslice_config = None
+    DOUT_S_ROOT = None
 
   # 3. If time series preprocess was used, pull out necessary config data
-  # TODO: is this the best way to determine if time series were generated?
+  # TODO: how do we determine if we actually generated timeseries?
   if os.path.isdir('postprocess'):
-    timeseries_config = dict()
-    for var in ['GET_REFCASE', 'RUN_REFCASE']:
-      timeslice_config[var] = subprocess.check_output('./xmlquery --value %s' %var, shell=True)
     os.chdir('postprocess')
-    timeseries_config['TIMESERIES_OUTPUT_ROOTDIR'] = subprocess.check_output('./pp_config --value --get TIMESERIES_OUTPUT_ROOTDIR', shell=True).rstrip()
+    TIMESERIES_OUTPUT_ROOTDIR = subprocess.check_output('./pp_config --value --get TIMESERIES_OUTPUT_ROOTDIR', shell=True).rstrip()
   else:
-    timeseries_config = None
+    TIMESERIES_OUTPUT_ROOTDIR = None
 
-  return timeslice_config, timeseries_config
+  return run_config, DOUT_S_ROOT, TIMESERIES_OUTPUT_ROOTDIR
 
 ################################################################################
 
@@ -78,18 +75,20 @@ def gen_catalog(case_root):
   logger = logging.getLogger(__name__)
 
   # 1. Find where data is
-  timeslice_config, timeseries_config = _find_data(case_root)
-  if (timeslice_config is None) and (timeseries_config is None):
+  run_config, DOUT_S_ROOT, TIMESERIES_OUTPUT_ROOTDIR = _find_data(case_root)
+  if (DOUT_S_ROOT is None) and (TIMESERIES_OUTPUT_ROOTDIR is None):
     logger.error('Error: can not find any data for %s' % case_root)
     sys.exit(1)
 
-  if timeseries_config:
-    # TODO: generate catalog instead of just printing this
-    logger.info(timeseries_config)
+  logger.info('run_config: %s' % run_config)
 
-  if timeslice_config:
+  if DOUT_S_ROOT:
     # TODO: generate catalog instead of just printing this
-    logger.info(timeslice_config)
+    logger.info('DOUT_S_ROOT: %s' % DOUT_S_ROOT)
+
+  if TIMESERIES_OUTPUT_ROOTDIR:
+    # TODO: generate catalog instead of just printing this
+    logger.info('TIMESERIES_OUTPUT_ROOTDIR: %s' % TIMESERIES_OUTPUT_ROOTDIR)
 
 ################################################################################
 

--- a/cesmcatalog/gen_CESM_catalog.py
+++ b/cesmcatalog/gen_CESM_catalog.py
@@ -12,12 +12,12 @@
         https://github.com/NCAR/CESM_postprocessing/wiki/cheyenne-and-DAV-quick-start-guide
 """
 
-import os
-import sys
-import subprocess
-import logging
 import argparse
 import fnmatch
+import logging
+import os
+import subprocess
+import sys
 
 import pandas as pd
 

--- a/cesmcatalog/gen_CESM_catalog.py
+++ b/cesmcatalog/gen_CESM_catalog.py
@@ -168,8 +168,8 @@ def _gen_timeseries_catalog(case_root, archive_root, run_config):
         catalog['parent_branch_year'] = entry_cnt * [-1]
         catalog['child_branch_year'] = entry_cnt * [-1]
 
-    logger.info('Creating {}...'.format(os.path.join(os.getcwd(), out_file)))
     pd.DataFrame(catalog).to_csv(out_file, index=False, columns=col_order, compression='gzip')
+    logger.info('Created {}'.format(os.path.join(os.getcwd(), out_file)))
 
 
 ################################################################################

--- a/cesmcatalog/gen_CESM_catalog.py
+++ b/cesmcatalog/gen_CESM_catalog.py
@@ -65,7 +65,7 @@ def _find_data(case_root):
         sys.exit(1)
 
     run_config = dict()
-    for var in ['GET_REFCASE', 'RUN_REFCASE', 'RUN_REFDATE', 'RUN_STARTDATE']:
+    for var in ['CASE', 'GET_REFCASE', 'RUN_REFCASE', 'RUN_REFDATE', 'RUN_STARTDATE']:
         run_config[var] = subprocess.check_output('./xmlquery --value {}'.format(var), shell=True)
     DOUT_S = subprocess.check_output('./xmlquery --value DOUT_S', shell=True)
     if DOUT_S == 'TRUE':
@@ -102,7 +102,7 @@ def _gen_timeseries_catalog(case_root, archive_root, run_config):
     # Set up logger
     # Define casename, file to create, and columns the catalog will contain
     logger = logging.getLogger(__name__)
-    casename = case_root.split('/')[-1]
+    casename = run_config['CASE']
     out_file = 'cesm_catalog.csv.gz'
     col_order = [
         'case',
@@ -131,7 +131,7 @@ def _gen_timeseries_catalog(case_root, archive_root, run_config):
 
     # Find each netcdf file in directory
     for root, dirs, files in os.walk('..'):
-        for ncfile in fnmatch.filter(files, '*.nc'):
+        for ncfile in fnmatch.filter(files, '{}*.nc'.format(casename)):
             # each file should be {casename}.{stream}.{variable}.{start_date}-{end_date}.nc
             # first we drop the leading {casename}.
             file_without_case = ncfile.replace(casename, '')[1:]

--- a/cesmcatalog/gen_CESM_catalog.py
+++ b/cesmcatalog/gen_CESM_catalog.py
@@ -28,7 +28,7 @@ def _parse_args():
     """ Wrapper for argparse, returns dictionary of arguments """
 
     parser = argparse.ArgumentParser(
-        description="Generate intake-esm catalog for a CESM case",
+        description='Generate intake-esm catalog for a CESM case',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
@@ -65,7 +65,7 @@ def _find_data(case_root):
         sys.exit(1)
 
     run_config = dict()
-    for var in ['GET_REFCASE', 'RUN_REFCASE']:
+    for var in ['GET_REFCASE', 'RUN_REFCASE', 'RUN_REFDATE', 'RUN_STARTDATE']:
         run_config[var] = subprocess.check_output('./xmlquery --value {}'.format(var), shell=True)
     DOUT_S = subprocess.check_output('./xmlquery --value DOUT_S', shell=True)
     if DOUT_S == 'TRUE':
@@ -192,7 +192,7 @@ def gen_catalog(case_root):
 
 ################################################################################
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     logging.basicConfig(format='%(levelname)s (%(funcName)s): %(message)s', level=logging.DEBUG)
     args = _parse_args()
     # strip trailing / from case root (if user provides it)

--- a/cesmcatalog/gen_CESM_catalog.py
+++ b/cesmcatalog/gen_CESM_catalog.py
@@ -23,148 +23,179 @@ import pandas as pd
 
 ################################################################################
 
+
 def _parse_args():
-  """ Wrapper for argparse, returns dictionary of arguments """
+    """ Wrapper for argparse, returns dictionary of arguments """
 
-  parser = argparse.ArgumentParser(description="Generate intake-esm catalog for a CESM case",
-                                   formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description="Generate intake-esm catalog for a CESM case",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
 
-  parser.add_argument('-c', '--case-root', action='store', dest='case_root', required=True,
-                      help='CESM case root to generate intake-esm catalog for')
+    parser.add_argument(
+        '-c',
+        '--case-root',
+        action='store',
+        dest='case_root',
+        required=True,
+        help='CESM case root to generate intake-esm catalog for',
+    )
 
-  return parser.parse_args()
+    return parser.parse_args()
+
 
 ################################################################################
+
 
 def _find_data(case_root):
-  logger = logging.getLogger(__name__)
+    logger = logging.getLogger(__name__)
 
-  # 1. change directory to case_root (if it exists)
-  try:
-    os.chdir(case_root)
-  except:
-    # TODO: set up logger instead of print statements
-    logger.error('{} does not exist'.format(case_root))
-    sys.exit(1)
+    # 1. change directory to case_root (if it exists)
+    try:
+        os.chdir(case_root)
+    except:
+        # TODO: set up logger instead of print statements
+        logger.error('{} does not exist'.format(case_root))
+        sys.exit(1)
 
-  # 2. Collect info on where time slice output is
-  if not os.path.isfile('./xmlquery'):
-    # TODO: set up logger instead of print statements
-    logger.error('Can not find xmlquery in {}'.format(case_root))
-    sys.exit(1)
+    # 2. Collect info on where time slice output is
+    if not os.path.isfile('./xmlquery'):
+        # TODO: set up logger instead of print statements
+        logger.error('Can not find xmlquery in {}'.format(case_root))
+        sys.exit(1)
 
-  run_config = dict()
-  for var in ['GET_REFCASE', 'RUN_REFCASE']:
-    run_config[var] = subprocess.check_output('./xmlquery --value {}'.format(var), shell=True)
-  DOUT_S = subprocess.check_output('./xmlquery --value DOUT_S', shell=True)
-  if DOUT_S == 'TRUE':
-    DOUT_S_ROOT = subprocess.check_output('./xmlquery --value DOUT_S_ROOT', shell=True)
-  else:
-    DOUT_S_ROOT = None
+    run_config = dict()
+    for var in ['GET_REFCASE', 'RUN_REFCASE']:
+        run_config[var] = subprocess.check_output('./xmlquery --value {}'.format(var), shell=True)
+    DOUT_S = subprocess.check_output('./xmlquery --value DOUT_S', shell=True)
+    if DOUT_S == 'TRUE':
+        DOUT_S_ROOT = subprocess.check_output('./xmlquery --value DOUT_S_ROOT', shell=True)
+    else:
+        DOUT_S_ROOT = None
 
-  # 3. If time series preprocess was used, pull out necessary config data
-  # TODO: how do we determine if we actually generated timeseries?
-  if os.path.isdir('postprocess'):
-    os.chdir('postprocess')
-    TIMESERIES_OUTPUT_ROOTDIR = subprocess.check_output('./pp_config --value --get TIMESERIES_OUTPUT_ROOTDIR', shell=True).rstrip()
-  else:
-    TIMESERIES_OUTPUT_ROOTDIR = None
+    # 3. If time series preprocess was used, pull out necessary config data
+    # TODO: how do we determine if we actually generated timeseries?
+    if os.path.isdir('postprocess'):
+        os.chdir('postprocess')
+        TIMESERIES_OUTPUT_ROOTDIR = subprocess.check_output(
+            './pp_config --value --get TIMESERIES_OUTPUT_ROOTDIR', shell=True
+        ).rstrip()
+    else:
+        TIMESERIES_OUTPUT_ROOTDIR = None
 
-  return run_config, DOUT_S_ROOT, TIMESERIES_OUTPUT_ROOTDIR
+    return run_config, DOUT_S_ROOT, TIMESERIES_OUTPUT_ROOTDIR
+
 
 ################################################################################
+
 
 def _gen_timeslice_catalog(case_root, archive_root, run_config):
-  # TODO: figure out how to generate catalog from time slice
-  logger = logging.getLogger(__name__)
-  logger.info('Will catalog files in {}'.format(archive_root))
+    # TODO: figure out how to generate catalog from time slice
+    logger = logging.getLogger(__name__)
+    logger.info('Will catalog files in {}'.format(archive_root))
+
 
 ################################################################################
+
 
 def _gen_timeseries_catalog(case_root, archive_root, run_config):
-  # Set up logger
-  # Define casename, file to create, and columns the catalog will contain
-  logger = logging.getLogger(__name__)
-  casename = case_root.split('/')[-1]
-  out_file = 'cesm_catalog.csv.gz'
-  col_order = ['case', 'component', 'stream', 'variable', 'start_date', 'end_date', 'path', 'parent_branch_year', 'child_branch_year', 'parent_case']
+    # Set up logger
+    # Define casename, file to create, and columns the catalog will contain
+    logger = logging.getLogger(__name__)
+    casename = case_root.split('/')[-1]
+    out_file = 'cesm_catalog.csv.gz'
+    col_order = [
+        'case',
+        'component',
+        'stream',
+        'variable',
+        'start_date',
+        'end_date',
+        'path',
+        'parent_branch_year',
+        'child_branch_year',
+        'parent_case',
+    ]
 
- # cd archive_root and make sure intake/ subdirectory exists (for output)
-  os.chdir(archive_root)
-  if not os.path.isdir('intake'):
-    os.mkdir('intake')
+    # cd archive_root and make sure intake/ subdirectory exists (for output)
+    os.chdir(archive_root)
+    if not os.path.isdir('intake'):
+        os.mkdir('intake')
 
-  # want paths in catalog to be relative to location of catalog
-  os.chdir('intake')
-  logger.info('Will catalog files in {}'.format(archive_root))
-  catalog = dict()
-  for col_name in col_order:
-    catalog[col_name] = []
+    # want paths in catalog to be relative to location of catalog
+    os.chdir('intake')
+    logger.info('Will catalog files in {}'.format(archive_root))
+    catalog = dict()
+    for col_name in col_order:
+        catalog[col_name] = []
 
-  # Find each netcdf file in directory
-  for root, dirs, files in os.walk('..'):
-    for ncfile in fnmatch.filter(files, '*.nc'):
-      # each file should be {casename}.{stream}.{variable}.{start_date}-{end_date}.nc
-      # first we drop the leading {casename}.
-      file_without_case = ncfile.replace(casename, '')[1:]
-      # then we split on .
-      file_info = file_without_case.split('.')
-      # {stream} will have at least one . in it
-      # figure out how many by location of date_range
-      # (only part of filename that should contain a '-')
-      for date_ind, info in enumerate(file_info):
-        if len(info.split('-'))>1:
-          break
+    # Find each netcdf file in directory
+    for root, dirs, files in os.walk('..'):
+        for ncfile in fnmatch.filter(files, '*.nc'):
+            # each file should be {casename}.{stream}.{variable}.{start_date}-{end_date}.nc
+            # first we drop the leading {casename}.
+            file_without_case = ncfile.replace(casename, '')[1:]
+            # then we split on .
+            file_info = file_without_case.split('.')
+            # {stream} will have at least one . in it
+            # figure out how many by location of date_range
+            # (only part of filename that should contain a '-')
+            for date_ind, info in enumerate(file_info):
+                if len(info.split('-')) > 1:
+                    break
 
-      # Enough to determine stream, variable, start_date, and end_date
-      catalog['stream'].append('.'.join(file_info[:date_ind-1]))
-      catalog['variable'].append(file_info[date_ind-1])
-      date_range = info.split('-')
-      catalog['start_date'].append(date_range[0])
-      catalog['end_date'].append(date_range[1])
+            # Enough to determine stream, variable, start_date, and end_date
+            catalog['stream'].append('.'.join(file_info[: date_ind - 1]))
+            catalog['variable'].append(file_info[date_ind - 1])
+            date_range = info.split('-')
+            catalog['start_date'].append(date_range[0])
+            catalog['end_date'].append(date_range[1])
 
-      # path should be relative to intake/, so we keep root
-      catalog['path'].append(os.path.join(root, ncfile))
-      # component is the name of the subdirectory of archive_root
-      catalog['component'].append(catalog['path'][-1].split('/')[1])
+            # path should be relative to intake/, so we keep root
+            catalog['path'].append(os.path.join(root, ncfile))
+            # component is the name of the subdirectory of archive_root
+            catalog['component'].append(catalog['path'][-1].split('/')[1])
 
-  # Columns that do not change by row
-  entry_cnt = len(catalog['path'])
-  catalog['case'] = entry_cnt*[casename]
-  if run_config['GET_REFCASE'] == 'TRUE':
-    catalog['parent_case'] = entry_cnt*[run_config['RUN_REFCASE']]
-    catalog['parent_branch_year'] = entry_cnt*[run_config['RUN_REFDATE']]
-    catalog['child_branch_year'] = entry_cnt*[run_config['RUN_STARTDATE']]
-  else:
-    catalog['parent_case'] = entry_cnt*['-']
-    catalog['parent_branch_year'] = entry_cnt*[-1]
-    catalog['child_branch_year'] = entry_cnt*[-1]
+    # Columns that do not change by row
+    entry_cnt = len(catalog['path'])
+    catalog['case'] = entry_cnt * [casename]
+    if run_config['GET_REFCASE'] == 'TRUE':
+        catalog['parent_case'] = entry_cnt * [run_config['RUN_REFCASE']]
+        catalog['parent_branch_year'] = entry_cnt * [run_config['RUN_REFDATE']]
+        catalog['child_branch_year'] = entry_cnt * [run_config['RUN_STARTDATE']]
+    else:
+        catalog['parent_case'] = entry_cnt * ['-']
+        catalog['parent_branch_year'] = entry_cnt * [-1]
+        catalog['child_branch_year'] = entry_cnt * [-1]
 
-  logger.info('Creating {}...'.format(os.path.join(os.getcwd(), out_file)))
-  pd.DataFrame(catalog).to_csv(out_file, index=False, columns=col_order, compression='gzip')
+    logger.info('Creating {}...'.format(os.path.join(os.getcwd(), out_file)))
+    pd.DataFrame(catalog).to_csv(out_file, index=False, columns=col_order, compression='gzip')
+
 
 ################################################################################
 
+
 def gen_catalog(case_root):
-  logger = logging.getLogger(__name__)
+    logger = logging.getLogger(__name__)
 
-  # 1. Find where data is
-  run_config, DOUT_S_ROOT, TIMESERIES_OUTPUT_ROOTDIR = _find_data(case_root)
-  if (DOUT_S_ROOT is None) and (TIMESERIES_OUTPUT_ROOTDIR is None):
-    logger.error('Error: can not find any data for {}'.format(case_root))
-    sys.exit(1)
+    # 1. Find where data is
+    run_config, DOUT_S_ROOT, TIMESERIES_OUTPUT_ROOTDIR = _find_data(case_root)
+    if (DOUT_S_ROOT is None) and (TIMESERIES_OUTPUT_ROOTDIR is None):
+        logger.error('Error: can not find any data for {}'.format(case_root))
+        sys.exit(1)
 
-  if TIMESERIES_OUTPUT_ROOTDIR:
-    _gen_timeseries_catalog(case_root, TIMESERIES_OUTPUT_ROOTDIR, run_config)
-  else: # only generate time slice catalog if time series not available
-    _gen_timeslice_catalog(case_root, DOUT_S, run_config)
+    if TIMESERIES_OUTPUT_ROOTDIR:
+        _gen_timeseries_catalog(case_root, TIMESERIES_OUTPUT_ROOTDIR, run_config)
+    else:  # only generate time slice catalog if time series not available
+        _gen_timeslice_catalog(case_root, DOUT_S, run_config)
+
 
 ################################################################################
 
 if __name__ == "__main__":
-  logging.basicConfig(format='%(levelname)s (%(funcName)s): %(message)s', level=logging.DEBUG)
-  args = _parse_args()
-  # strip trailing / from case root (if user provides it)
-  while args.case_root[-1] == '/':
-    args.case_root = args.case_root[:-1]
-  gen_catalog(args.case_root)
+    logging.basicConfig(format='%(levelname)s (%(funcName)s): %(message)s', level=logging.DEBUG)
+    args = _parse_args()
+    # strip trailing / from case root (if user provides it)
+    while args.case_root[-1] == '/':
+        args.case_root = args.case_root[:-1]
+    gen_catalog(args.case_root)

--- a/cesmcatalog/gen_CESM_catalog.py
+++ b/cesmcatalog/gen_CESM_catalog.py
@@ -75,11 +75,11 @@ def _find_data(case_root):
             subprocess.check_output('./xmlquery --value CIMEROOT', shell=True), 'scripts', 'Tools'
         )
     )
-    from standard_script_setup import *  # noqa: F406
+    import standard_script_setup  # noqa: F401 (used to get path to CIME.case in path)
     from CIME.case import Case
 
     run_config = dict()
-    with Case(case_root, read_only=False) as case:
+    with Case(case_root, read_only=True) as case:
         for var in ['CASE', 'GET_REFCASE', 'RUN_REFCASE', 'RUN_REFDATE', 'RUN_STARTDATE']:
             run_config[var] = case.get_value(var)
 

--- a/cesmcatalog/gen_CESM_catalog.py
+++ b/cesmcatalog/gen_CESM_catalog.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+"""
+  Goal: a script that gets pointed to a CESM case directory and generates
+        an intake-esm catalog of output in the short-term archive directory
+
+  Current state: a script that gets pointed to a CESM case directory and prints
+                 some environment variables that will be necessary for above
+
+  NOTE: this script needs to be run in the CESM postprocessing python environment,
+        which is still based on python 2.7. Follow instructions at
+
+        https://github.com/NCAR/CESM_postprocessing/wiki/cheyenne-and-DAV-quick-start-guide
+"""
+
+import os
+import sys
+import subprocess
+import logging
+import argparse
+
+################################################################################
+
+def _parse_args():
+  """ Wrapper for argparse, returns dictionary of arguments """
+
+  parser = argparse.ArgumentParser(description="Generate intake-esm catalog for a CESM case",
+                                   formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+  parser.add_argument('-c', '--case-root', action='store', dest='case_root', required=True,
+                      help='CESM case root to generate intake-esm catalog for')
+
+  return parser.parse_args()
+
+################################################################################
+
+def _find_data(case_root):
+  logger = logging.getLogger(__name__)
+
+  # 1. change directory to case_root (if it exists)
+  try:
+    os.chdir(case_root)
+  except:
+    # TODO: set up logger instead of print statements
+    logger.error('%s does not exist' % case_root)
+    sys.exit(1)
+
+  # 2. Collect info on where time slice output is
+  if not os.path.isfile('./xmlquery'):
+    # TODO: set up logger instead of print statements
+    logger.error('Can not find xmlquery in %s' % case_root)
+    sys.exit(1)
+
+  DOUT_S = subprocess.check_output('./xmlquery --value DOUT_S', shell=True)
+  if DOUT_S == 'TRUE':
+    timeslice_config = dict()
+    for var in ['DOUT_S_ROOT', 'GET_REFCASE', 'RUN_REFCASE']:
+      timeslice_config[var] = subprocess.check_output('./xmlquery --value %s' % var, shell=True)
+    # Proof of concept; show what data we've gleaned
+  else:
+    timeslice_config = None
+
+  # 3. If time series preprocess was used, pull out necessary config data
+  # TODO: is this the best way to determine if time series were generated?
+  if os.path.isdir('postprocess'):
+    timeseries_config = dict()
+    for var in ['GET_REFCASE', 'RUN_REFCASE']:
+      timeslice_config[var] = subprocess.check_output('./xmlquery --value %s' %var, shell=True)
+    os.chdir('postprocess')
+    timeseries_config['TIMESERIES_OUTPUT_ROOTDIR'] = subprocess.check_output('./pp_config --value --get TIMESERIES_OUTPUT_ROOTDIR', shell=True).rstrip()
+  else:
+    timeseries_config = None
+
+  return timeslice_config, timeseries_config
+
+################################################################################
+
+def gen_catalog(case_root):
+  logger = logging.getLogger(__name__)
+
+  # 1. Find where data is
+  timeslice_config, timeseries_config = _find_data(case_root)
+  if (timeslice_config is None) and (timeseries_config is None):
+    logger.error('Error: can not find any data for %s' % case_root)
+    sys.exit(1)
+
+  if timeseries_config:
+    # TODO: generate catalog instead of just printing this
+    logger.info(timeseries_config)
+
+  if timeslice_config:
+    # TODO: generate catalog instead of just printing this
+    logger.info(timeslice_config)
+
+################################################################################
+
+if __name__ == "__main__":
+  logging.basicConfig(format='%(levelname)s (%(funcName)s): %(message)s', level=logging.DEBUG)
+  args = _parse_args()
+  gen_catalog(args.case_root)

--- a/cesmcatalog/gen_CESM_catalog.py
+++ b/cesmcatalog/gen_CESM_catalog.py
@@ -38,6 +38,13 @@ def _parse_args():
         required=True,
         help='CESM case root to generate intake-esm catalog for',
     )
+    parser.add_argument(
+        '-d',
+        '--debug',
+        action='store_true',
+        dest='debug',
+        help='Add additional output for debugging',
+    )
 
     return parser.parse_args()
 
@@ -206,7 +213,10 @@ def gen_catalog(case_root):
 
 if __name__ == '__main__':
     args = _parse_args()
-    log_level = logging.INFO
+    if args.debug:
+        log_level = logging.DEBUG
+    else:
+        log_level = logging.INFO
     logging.basicConfig(format='%(levelname)s (%(funcName)s): %(message)s', level=log_level)
     # strip trailing / from case root (if user provides it)
     while args.case_root[-1] == '/':

--- a/cesmcatalog/gen_CESM_catalog.py
+++ b/cesmcatalog/gen_CESM_catalog.py
@@ -187,7 +187,7 @@ def gen_catalog(case_root):
     if TIMESERIES_OUTPUT_ROOTDIR:
         _gen_timeseries_catalog(case_root, TIMESERIES_OUTPUT_ROOTDIR, run_config)
     else:  # only generate time slice catalog if time series not available
-        _gen_timeslice_catalog(case_root, DOUT_S, run_config)
+        _gen_timeslice_catalog(case_root, DOUT_S_ROOT, run_config)
 
 
 ################################################################################

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ select = B,C,E,F,W,T4,B9
 
 [isort]
 known_first_party=cesmcatalog
-known_third_party=pandas,pkg_resources,setuptools
+known_third_party=pkg_resources,setuptools
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ select = B,C,E,F,W,T4,B9
 
 [isort]
 known_first_party=cesmcatalog
-known_third_party=pkg_resources,setuptools
+known_third_party=pandas,pkg_resources,setuptools
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0


### PR DESCRIPTION
Added a script that generates an intake catalog for time series data generated by CESM if `pyReshaper` was run in post-processing.

```
$ ./gen_CESM_catalog.py -c /glade/p/cgd/oce/people/mlevy/cases/b.e22b05.B1850.f09_g17.timeseries_output_for_intake/
INFO (_gen_timeseries_catalog): Will catalog files in /glade/p/cgd/oce/people/mlevy/archive/b.e22b05.B1850.f09_g17.timeseries_output_for_intake
INFO (_gen_timeseries_catalog): Creating /glade/p/cgd/oce/people/mlevy/archive/b.e22b05.B1850.f09_g17.timeseries_output_for_intake/intake/cesm_catalog.csv.gz...
```

```
$ zcat /glade/p/cgd/oce/people/mlevy/archive/b.e22b05.B1850.f09_g17.timeseries_output_for_intake/intake/cesm_catalog.csv.gz | head -n 4
case,component,stream,variable,start_date,end_date,path,parent_branch_year,child_branch_year,parent_case
b.e22b05.B1850.f09_g17.timeseries_output_for_intake,atm,cam.h0,TAUBLJY,000101,000112,../atm/proc/tseries/month_1/b.e22b05.B1850.f09_g17.timeseries_output_for_intake.cam.h0.TAUBLJY.000101-000112.nc,-1,-1,-
b.e22b05.B1850.f09_g17.timeseries_output_for_intake,atm,cam.h0,num_c2SFWET,000101,000112,../atm/proc/tseries/month_1/b.e22b05.B1850.f09_g17.timeseries_output_for_intake.cam.h0.num_c2SFWET.000101-000112.nc,-1,-1,-
b.e22b05.B1850.f09_g17.timeseries_output_for_intake,atm,cam.h0,dst_c3,000101,000112,../atm/proc/tseries/month_1/b.e22b05.B1850.f09_g17.timeseries_output_for_intake.cam.h0.dst_c3.000101-000112.nc,-1,-1,-
```

Note that this file assumes `intake-esm` can handle a relative path from the `csv.gz` file to the netCDF data.

I can think of several improvements this script needs, some which might belong in this PR and others that might spawn new issue tickets.

1. Error handling if file name doesn't fit the `{casename}.{stream}.{variable}.{start_date}-{end_date}.nc` template (e.g. if history files and time series are collocated, which is default behavior of CESM postprocessing)
1. Backup plan for determining location of time series if `pp_config` is not available
1. I don't think

   ```
    catalog['parent_branch_year'] = entry_cnt*[run_config['RUN_REFDATE']]
    catalog['child_branch_year'] = entry_cnt*[run_config['RUN_STARTDATE']]
   ```

   will work for determining branch point if a run is based off a reference case, as they aren't in `run_config` yet

And I'm sure additional issues will come up, but I wanted to open this PR to advertise that this script is working in tightly controlled instances.

Closes #2 
